### PR TITLE
NO-REF: minor ui changes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "proseWrap": "preserve"
+}

--- a/wiki/css/base.css
+++ b/wiki/css/base.css
@@ -56,6 +56,12 @@ body {
 }
 
 .vignette-layer {
+  display: none;
+}
+
+body.distraction-free .vignette-layer,
+body.focus-mode .vignette-layer {
+  display: block;
   position: fixed;
   inset: 0;
   z-index: 1;
@@ -67,7 +73,8 @@ body {
   );
 }
 
-[data-theme="light"] .vignette-layer {
+[data-theme="light"] body.distraction-free .vignette-layer,
+[data-theme="light"] body.focus-mode .vignette-layer {
   background: radial-gradient(
     ellipse 110% 85% at 50% 0%,
     transparent 42%,

--- a/wiki/css/components.css
+++ b/wiki/css/components.css
@@ -427,28 +427,6 @@
 }
 
 /* ═══════════════════════════════════════════════
-   CODE LANGUAGE LABELS
-   ═══════════════════════════════════════════════ */
-.code-lang-label {
-  position: absolute;
-  top: var(--s3);
-  left: var(--s4);
-  font-family: var(--font-mono);
-  font-size: 0.68rem;
-  font-weight: 500;
-  color: var(--text-subtle);
-  letter-spacing: 0.04em;
-  text-transform: lowercase;
-  pointer-events: none;
-  user-select: none;
-}
-
-/* Shift copy button when lang label present */
-.markdown-body pre:has(.code-lang-label) code {
-  padding-top: var(--s5);
-}
-
-/* ═══════════════════════════════════════════════
    SETTINGS PANEL
    ═══════════════════════════════════════════════ */
 .settings-panel {
@@ -664,6 +642,7 @@
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-muted);
+  text-align: center;
   cursor: pointer;
   transition: border-color var(--t-fast), color var(--t-fast),
     background var(--t-fast);

--- a/wiki/css/view-content.css
+++ b/wiki/css/view-content.css
@@ -110,9 +110,7 @@ body.distraction-free .sticky-section-header {
   display: flex;
   align-items: flex-start;
   gap: var(--s8);
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: var(--s8) var(--s6) var(--s20);
+  padding: var(--s8) var(--layout-padding, 10%) var(--s20);
 }
 
 /* ─── TOC Sidebar ─── */
@@ -281,14 +279,13 @@ body.distraction-free .sticky-section-header {
 .markdown-body {
   flex: 1;
   min-width: 0;
-  max-width: var(--content-width, 80ch);
   overflow-x: hidden;
   overflow-wrap: break-word;
   word-break: break-word;
   order: 1;
   color: var(--text-body);
   font-size: var(--text-base);
-  line-height: 1.75;
+  line-height: 1.6;
 }
 
 /* Loading state */
@@ -325,8 +322,8 @@ body.distraction-free .sticky-section-header {
   color: var(--text-heading);
   letter-spacing: -0.02em;
   line-height: 1.25;
-  margin: var(--s12) 0 var(--s4);
-  padding-top: var(--s4);
+  margin: var(--s8) 0 var(--s3);
+  padding-top: var(--s3);
 }
 .markdown-body h3 {
   font-size: var(--text-xl);
@@ -334,13 +331,13 @@ body.distraction-free .sticky-section-header {
   color: var(--text-heading);
   letter-spacing: -0.01em;
   line-height: 1.3;
-  margin: var(--s8) 0 var(--s3);
+  margin: var(--s6) 0 var(--s2);
 }
 .markdown-body h4 {
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-body);
-  margin: var(--s6) 0 var(--s2);
+  margin: var(--s4) 0 var(--s2);
 }
 
 .markdown-body h2,
@@ -351,7 +348,7 @@ body.distraction-free .sticky-section-header {
 
 /* Paragraphs */
 .markdown-body p {
-  margin-bottom: var(--s4);
+  margin-bottom: var(--s3);
 }
 .markdown-body p:last-child {
   margin-bottom: 0;
@@ -440,14 +437,16 @@ body.distraction-free .sticky-section-header {
   border: 1px solid var(--border-2);
   border-radius: var(--r);
   padding: 0;
-  margin: var(--s5) 0;
+  margin: var(--s4) 0;
   overflow-x: auto;
   font-size: var(--text-sm);
-  line-height: 1.6;
+  line-height: 1;
 }
-.markdown-body pre code {
+.markdown-body pre code,
+.markdown-body pre code.hljs {
   display: block;
-  padding: var(--s5);
+  padding: 4cap var(--s2);
+  line-height: 1;
 }
 /* right-edge scroll fade — only when no header to show overflow */
 .markdown-body pre:not(.pre--collapsible)::after {
@@ -493,12 +492,12 @@ pre.has-line-numbers {
 .code-header {
   display: flex;
   align-items: center;
-  padding: var(--s2) var(--s3);
+  padding: 2px var(--s3);
   border-bottom: 1px solid var(--border-2);
   background: rgba(0, 0, 0, 0.15);
   border-radius: var(--r) var(--r) 0 0;
   gap: var(--s3);
-  min-height: 32px;
+  min-height: 26px;
 }
 .code-traffic-lights {
   display: flex;
@@ -531,28 +530,38 @@ pre.has-line-numbers {
   user-select: none;
 }
 .copy-btn {
-  flex-shrink: 0;
+  position: absolute;
+  bottom: var(--s2);
+  right: var(--s2);
   width: 26px;
   height: 26px;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: transparent;
-  border: 1px solid transparent;
+  background: var(--surface-2);
+  border: 1px solid var(--border-2);
   border-radius: var(--r-sm);
   color: var(--text-subtle);
   font-size: var(--text-sm);
   cursor: pointer;
+  opacity: 0;
+  pointer-events: auto;
   transition: color var(--t-fast), border-color var(--t-fast),
-    background var(--t-fast);
+    background var(--t-fast), opacity var(--t-fast);
+  z-index: 2;
+}
+.markdown-body pre:hover .copy-btn {
+  opacity: 1;
 }
 .copy-btn:hover {
   color: var(--text-body);
-  border-color: var(--border-2);
+  border-color: var(--border);
   background: var(--surface-3);
 }
 .copy-btn.copied {
   color: #10b981;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 /* ═══════════════════════════════════════════════
@@ -1020,22 +1029,10 @@ pre.has-line-numbers {
 .markdown-body blockquote.callout--collapsible {
   max-height: 240px;
   overflow: hidden;
-  position: relative;
-}
-.markdown-body blockquote.callout--collapsible::after {
-  content: "";
-  position: absolute;
-  inset: auto 0 0 0;
-  height: 56px;
-  background: linear-gradient(to bottom, transparent, var(--surface));
-  pointer-events: none;
 }
 .markdown-body blockquote.callout--collapsible.callout--expanded {
   max-height: none;
   overflow: visible;
-}
-.markdown-body blockquote.callout--collapsible.callout--expanded::after {
-  display: none;
 }
 .callout-expand-btn {
   display: block;

--- a/wiki/js/content.js
+++ b/wiki/js/content.js
@@ -80,7 +80,7 @@ function addCodeBlockHeader(contentEl, onCopyError = () => {}) {
     });
     header.appendChild(lights);
 
-    // Lang label (centered)
+    // Lang label (centered in header)
     const langMatch = code?.className.match(/language-(\w+)/);
     if (langMatch && langMatch[1] !== "mermaid") {
       const label = document.createElement("span");
@@ -89,7 +89,9 @@ function addCodeBlockHeader(contentEl, onCopyError = () => {}) {
       header.appendChild(label);
     }
 
-    // Copy button (icon-only ⧉)
+    pre.insertBefore(header, pre.firstChild);
+
+    // Copy button — floats inside code body, hidden until hover
     const btn = document.createElement("button");
     btn.className = "copy-btn";
     btn.title = "Copy code";
@@ -108,9 +110,7 @@ function addCodeBlockHeader(contentEl, onCopyError = () => {}) {
         })
         .catch(() => onCopyError());
     });
-    header.appendChild(btn);
-
-    pre.insertBefore(header, pre.firstChild);
+    pre.appendChild(btn);
   });
 }
 
@@ -123,13 +123,24 @@ function addCopyButtons(contentEl, onCopyError = () => {}) {
 function styleCallouts(contentEl) {
   contentEl.querySelectorAll("blockquote").forEach((bq) => {
     const text = bq.textContent.trim();
-    if (text.startsWith("🎯")) bq.classList.add("callout", "callout-interview");
+    let calloutClass = null;
+    if (text.startsWith("🎯")) calloutClass = "callout-interview";
     else if (text.startsWith("⚠️") || text.startsWith("⚠"))
-      bq.classList.add("callout", "callout-warning");
-    else if (text.startsWith("🧠"))
-      bq.classList.add("callout", "callout-thought");
+      calloutClass = "callout-warning";
+    else if (text.startsWith("🧠")) calloutClass = "callout-thought";
     else if (text.startsWith("⚖️") || text.startsWith("⚖"))
-      bq.classList.add("callout", "callout-decision");
+      calloutClass = "callout-decision";
+    if (!calloutClass) return;
+    bq.classList.add("callout", calloutClass);
+
+    // Strip leading emoji from first paragraph so CSS ::before doesn't duplicate it
+    const firstP = bq.querySelector("p");
+    if (firstP?.firstChild?.nodeType === Node.TEXT_NODE) {
+      const t = firstP.firstChild.textContent;
+      const chars = [...t];
+      const skip = chars[1] === "️" ? 2 : 1;
+      firstP.firstChild.textContent = chars.slice(skip).join("").trimStart();
+    }
   });
 }
 
@@ -446,6 +457,7 @@ function addCollapsibleCodeBlocks(contentEl) {
     btn.addEventListener("click", () => {
       const expanded = pre.classList.toggle("pre--expanded");
       btn.textContent = expanded ? "Show less" : "Show more";
+      if (!expanded) pre.scrollIntoView({ behavior: "smooth", block: "start" });
     });
     pre.appendChild(btn);
   });
@@ -499,7 +511,7 @@ function addCollapsibleCallouts(contentEl) {
       const expanded = bq.classList.toggle("callout--expanded");
       btn.textContent = expanded ? "Show less" : "Show more";
     });
-    bq.appendChild(btn);
+    bq.insertAdjacentElement("afterend", btn);
   });
 }
 

--- a/wiki/js/render.js
+++ b/wiki/js/render.js
@@ -763,7 +763,12 @@ async function showHoverPreview(link, path) {
   previewEl.innerHTML = '<div class="loading">Loading preview...</div>';
   previewEl.classList.add("visible");
 
-  const SKIP_PREFIXES = ["prerequisites:", "table of contents"];
+  const SKIP_PREFIXES = [
+    "prerequisites:",
+    "prerequisites",
+    "prerequisite",
+    "table of contents",
+  ];
 
   try {
     const md = await fetchText(path, signal);
@@ -771,23 +776,25 @@ async function showHoverPreview(link, path) {
     if (!previewEl.classList.contains("visible")) return;
     let extract = "";
 
-    // Limit scan to first 600 chars; enough for title + first few paragraphs
-    const preview = md.slice(0, 600);
-
-    // Match TLDR section first
-    const tldrMatch = preview.match(/##\s*TL;?DR\s*\n([\s\S]*?)(?=\n##|$)/i);
+    // Search whole doc for TLDR section
+    const tldrMatch = md.match(/##\s*TL;?DR\s*\n([\s\S]*?)(?=\n##|\n#|$)/i);
     if (tldrMatch && tldrMatch[1].trim()) {
       extract = tldrMatch[1].trim();
     } else {
-      // Fallback: first non-metadata paragraph
-      const textWithoutTitle = preview.replace(/^#+ .*/gm, "").trim();
-      const paras = textWithoutTitle.split("\n\n");
+      // Fallback: first substantive paragraph that isn't prereqs/TOC/heading
+      const withoutTitle = md.replace(/^#[^#][^\n]*\n/, "");
+      const paras = withoutTitle.split("\n\n");
       extract =
-        paras.find(
-          (p) =>
-            p.trim() &&
-            !SKIP_PREFIXES.some((s) => p.trim().toLowerCase().startsWith(s))
-        ) || "";
+        paras
+          .find((p) => {
+            const t = p.trim().toLowerCase();
+            return (
+              t.length > 20 &&
+              !t.startsWith("#") &&
+              !SKIP_PREFIXES.some((s) => t.startsWith(s))
+            );
+          })
+          ?.trim() || "";
     }
 
     if (!extract) throw new Error("Empty");

--- a/wiki/js/storage.js
+++ b/wiki/js/storage.js
@@ -525,6 +525,11 @@ function applySettingsToDOM(s) {
   root.setProperty("--border", bg.border);
   root.setProperty("--border-2", bg.border2);
   root.setProperty("--bg-translucent", bg.translucent);
+  root.setProperty("--glass-bg", bg.translucent);
+  root.setProperty(
+    "--glass-border",
+    dark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.08)"
+  );
 
   const tcList = dark ? DARK_TEXT_COLORS : LIGHT_TEXT_COLORS;
   const tc = tcList.find((t) => t.id === s.textColorId) || tcList[0];
@@ -551,8 +556,8 @@ function applySettingsToDOM(s) {
   const sizes = { S: "14px", M: "16px", L: "18px" };
   document.documentElement.style.fontSize = sizes[s.fontSize] || "16px";
 
-  const widths = { Narrow: "68ch", Default: "80ch", Wide: "120ch" };
-  root.setProperty("--content-width", widths[s.contentWidth] || "80ch");
+  const widths = { Narrow: "20%", Default: "10%", Wide: "5%" };
+  root.setProperty("--layout-padding", widths[s.contentWidth] || "10%");
 
   document.dispatchEvent(
     new CustomEvent("wiki:themechange", { detail: { theme } })

--- a/wiki/tests/e2e/test_content_enhancements.py
+++ b/wiki/tests/e2e/test_content_enhancements.py
@@ -486,18 +486,18 @@ def test_code_block_has_traffic_lights(page, base_url):
 
 
 def test_code_block_copy_button_in_header(page, base_url):
-    """Copy button lives inside .code-header and shows the ⧉ glyph."""
+    """Copy button lives inside <pre> (after .code-header) and shows the ⧉ glyph."""
     _load_mock_article(page, base_url, ARTICLE_WITH_CODE, slug="code-copybtn")
     page.wait_for_selector("#markdown-body pre", timeout=5_000)
 
     result = page.evaluate("""() => {
-        const header = document.querySelector('#markdown-body .code-header');
-        if (!header) return { found: false };
-        const btn = header.querySelector('.copy-btn');
+        const pre = document.querySelector('#markdown-body pre');
+        if (!pre) return { found: false };
+        const btn = pre.querySelector('.copy-btn');
         return { found: true, hasCopyBtn: !!btn, text: btn?.textContent?.trim() };
     }""")
-    assert result["found"], ".code-header not found inside <pre>"
-    assert result["hasCopyBtn"], ".copy-btn not found inside .code-header"
+    assert result["found"], "<pre> not found inside #markdown-body"
+    assert result["hasCopyBtn"], ".copy-btn not found inside <pre>"
     assert result["text"] == "⧉", (
         f"Expected copy button glyph '⧉', got '{result['text']}'"
     )
@@ -589,17 +589,18 @@ def test_tall_callout_gets_collapsible_class(page, base_url):
     result = page.evaluate("""() => {
         const callout = document.querySelector('.callout');
         if (!callout) return { found: false };
+        const nextEl = callout.nextElementSibling;
         return {
             found: true,
             isCollapsible: callout.classList.contains('callout--collapsible'),
-            hasBtn: !!callout.querySelector('.callout-expand-btn'),
+            hasBtn: nextEl?.classList.contains('callout-expand-btn') ?? false,
         };
     }""")
     assert result["found"], "No .callout element found in article"
     assert result["isCollapsible"], (
         ".callout is missing .callout--collapsible on a tall callout"
     )
-    assert result["hasBtn"], ".callout is missing .callout-expand-btn"
+    assert result["hasBtn"], ".callout-expand-btn not found after .callout"
 
 
 def test_callout_expand_btn_toggles_expanded(page, base_url):

--- a/wiki/tests/e2e/test_content_width.py
+++ b/wiki/tests/e2e/test_content_width.py
@@ -12,7 +12,7 @@ def _open_settings(page):
 
 def _get_content_width_var(page):
     return page.evaluate(
-        "() => document.documentElement.style.getPropertyValue('--content-width').trim()"
+        "() => document.documentElement.style.getPropertyValue('--layout-padding').trim()"
     )
 
 
@@ -38,27 +38,27 @@ def test_content_width_default_is_active_on_open(wiki_page):
 
 
 def test_narrow_sets_content_width_68ch(wiki_page):
-    """clicking Narrow sets --content-width to 68ch."""
+    """clicking Narrow sets --layout-padding to 20%."""
     _open_settings(wiki_page)
     wiki_page.locator("#settings-widths .settings-size-btn").nth(0).click()  # Narrow
-    assert _get_content_width_var(wiki_page) == "68ch"
+    assert _get_content_width_var(wiki_page) == "20%"
 
 
 def test_default_sets_content_width_80ch(wiki_page):
-    """clicking Default sets --content-width to 80ch."""
+    """clicking Default sets --layout-padding to 10%."""
     _open_settings(wiki_page)
     wiki_page.locator("#settings-widths .settings-size-btn").nth(
         0
     ).click()  # Narrow first
     wiki_page.locator("#settings-widths .settings-size-btn").nth(1).click()  # Default
-    assert _get_content_width_var(wiki_page) == "80ch"
+    assert _get_content_width_var(wiki_page) == "10%"
 
 
 def test_wide_sets_content_width_120ch(wiki_page):
-    """clicking Wide sets --content-width to 120ch."""
+    """clicking Wide sets --layout-padding to 5%."""
     _open_settings(wiki_page)
     wiki_page.locator("#settings-widths .settings-size-btn").nth(2).click()  # Wide
-    assert _get_content_width_var(wiki_page) == "120ch"
+    assert _get_content_width_var(wiki_page) == "5%"
 
 
 def test_width_button_gets_active_class(wiki_page):
@@ -97,6 +97,6 @@ def test_content_width_persists_across_reload(page, base_url):
     assert stored_after == "Narrow"
 
     width_var = page.evaluate(
-        "() => document.documentElement.style.getPropertyValue('--content-width').trim()"
+        "() => document.documentElement.style.getPropertyValue('--layout-padding').trim()"
     )
-    assert width_var == "68ch"
+    assert width_var == "20%"

--- a/wiki/tests/e2e/test_search.py
+++ b/wiki/tests/e2e/test_search.py
@@ -28,15 +28,18 @@ def test_arrow_keys_cycle_results(wiki_page):
     _open_search(wiki_page)
     # "cache" matches many sections inside the large caching.md → guaranteed ≥2 results.
     wiki_page.fill("#gsearch-input", "cache")
-    wiki_page.wait_for_selector(".gsearch-result")
-    # Wait until at least two results are rendered before navigating.
+    # Wait for ≥2 results and let the 150ms debounce fully settle.
     wiki_page.locator(".gsearch-result").nth(1).wait_for()
+    wiki_page.wait_for_timeout(200)
 
-    wiki_page.locator("#gsearch-input").focus()
     wiki_page.keyboard.press("ArrowDown")
-    first = wiki_page.locator(".gsearch-result.selected").inner_text()
+    wiki_page.wait_for_selector(".gsearch-result.selected")
+    first = wiki_page.locator(".gsearch-result.selected").first.inner_text()
+
     wiki_page.keyboard.press("ArrowDown")
-    second = wiki_page.locator(".gsearch-result.selected").inner_text()
+    wiki_page.wait_for_selector(".gsearch-result.selected")
+    second = wiki_page.locator(".gsearch-result.selected").first.inner_text()
+
     assert first != second
 
 


### PR DESCRIPTION
## Description

1. Vignette gradient restricted to distraction-free and focus modes; removed from default reading mode
2. Fixed scroll locking on non-fullscreen viewports - `overflow-x`: hidden on html was blocking vertical scroll in Safari/Chrome
3. Fixed double emoji in callout boxes — stripped leading text emoji after CSS `::before` already renders it
4. Code block copy button hidden by default, revealed on `pre:hover`; fixed traffic-light controls overlapping the language label
5. Content width selector (Default/Narrow/Wide) applies symmetric percentage-based side padding, keeping content centered
6. Fixed topbar glass background not updating on theme switch
7. Fixed article hover preview showing Prerequisites section instead of TL;DR
8. Tightened code block density (`line-height` + `padding`, overriding `highlight.js` defaults)
9. removed callout fade shadow; fixed "Show less" scrolling to block top;
10. added `.prettierrc` to prevent formatter from merging consecutive blockquote lines